### PR TITLE
Normalize the C++ to 17 standards

### DIFF
--- a/src/wt-helpers/InputGroup.h
+++ b/src/wt-helpers/InputGroup.h
@@ -13,11 +13,11 @@ namespace Wt {
 }
 
 template <typename T>
-class InputGroup : public Wt::WCompositeWidget
+class InputGroup final : public Wt::WCompositeWidget
 {
 public:
     template <typename ...Args>
-    inline InputGroup(Args&& ...args)
+    InputGroup(Args&& ...args)
       : Wt::WCompositeWidget(std::make_unique<Wt::WContainerWidget>())
     {
         setStyleClass("input-group");
@@ -34,32 +34,32 @@ public:
     }
 
     template <typename Widget, typename ...Args>
-    inline Widget* prepend(Args&& ...args)
+    Widget* prepend(Args&& ...args)
     {
         return prependContainer->addNew<Widget>(std::forward<Args>(args)...);
     }
 
     template <typename Widget, typename ...Args>
-    inline Widget* append(Args&& ...args)
+    Widget* append(Args&& ...args)
     {
         return appendContainer->addNew<Widget>(std::forward<Args>(args)...);
     }
 
-    inline Wt::WText* prependText(const Wt::WString& text)
+    Wt::WText* prependText(const Wt::WString& text)
     {
         auto span = prependContainer->addNew<Wt::WText>(text);
         span->setStyleClass("input-group-text");
         return span;
     }
 
-    inline Wt::WText* appendText(const Wt::WString& text)
+    Wt::WText* appendText(const Wt::WString& text)
     {
         auto span = appendContainer->addNew<Wt::WText>(text);
         span->setStyleClass("input-group-text");
         return span;
     }
 
-    inline T* getMainInput() const { return mainInput; }
+    T* getMainInput() const { return mainInput; }
 
 private:
     T* mainInput;


### PR DESCRIPTION
1. Always use T for template types, though `Widget` may work in this scenario
2. Use `is_convertible`, for proxy classes
3. Use `final` if the class shouldn't be inherited from as it's a utility class
4. Functions inside class definition are implicitly inline
5. Functions inside class definition should be very very short (generally just getters/setters)
6. Include only what you use