### PR TITLE
Fixes for TransientWidget

### DIFF
--- a/src/wt-helpers/InputGroup.h
+++ b/src/wt-helpers/InputGroup.h
@@ -60,7 +60,7 @@ public:
         return span;
     }
 
-    T const* getMainInput() const { return mainInput; }
+    T* getMainInput() const { return mainInput; }
 
 private:
     T* mainInput;

--- a/src/wt-helpers/InputGroup.h
+++ b/src/wt-helpers/InputGroup.h
@@ -60,7 +60,7 @@ public:
         return span;
     }
 
-    T* getMainInput() const { return mainInput; }
+    T* getMainInput() { return mainInput; }
 
 private:
     T* mainInput;

--- a/src/wt-helpers/TransientWidget.h
+++ b/src/wt-helpers/TransientWidget.h
@@ -73,11 +73,11 @@ inline void TransientWidget<T>::setInDom(bool inDom)
 {
     if (inDom && uniquePtr)
     {
-        ptr = parent->addWidget(std::move(uniquePtr));
+        ptr = parent->addWidget(uniquePtr);
     }
     else if (ptr)
     {
-        uniquePtr = std::move(parent->removeChild(ptr));
+        uniquePtr.set(parent->removeChild(ptr));
         ptr = nullptr;
     }
 

--- a/src/wt-helpers/TransientWidget.h
+++ b/src/wt-helpers/TransientWidget.h
@@ -77,7 +77,7 @@ inline void TransientWidget<T>::setInDom(bool inDom)
     }
     else if (ptr)
     {
-        uniquePtr.set(parent->removeChild(ptr));
+        uniquePtr.swap(parent->removeChild(ptr));
         ptr = nullptr;
     }
 

--- a/src/wt-helpers/TransientWidget.h
+++ b/src/wt-helpers/TransientWidget.h
@@ -77,7 +77,7 @@ inline void TransientWidget<T>::setInDom(bool inDom)
     }
     else if (ptr)
     {
-        uniquePtr.swap(parent->removeChild(ptr));
+        uniquePtr = std::move(parent->removeChild(ptr));
         ptr = nullptr;
     }
 

--- a/src/wt-helpers/TransientWidget.h
+++ b/src/wt-helpers/TransientWidget.h
@@ -15,7 +15,10 @@ namespace Wt {
 template <class T>
 class TransientWidget final
 {
-    static_assert(std::is_convertible<T, Wt::WWidget>::value, "Transient widget must be a WWidget");
+    static_assert(std::is_base_of<Wt::WWidget, T>::value
+        || std::is_convertible<T*, Wt::WWidget*>::value
+        || std::is_convertible<T, Wt::WWidget>::value,
+         "Transient widget must be a WWidget");
 
 public:
     template<class... Args>

--- a/src/wt-helpers/TransientWidget.h
+++ b/src/wt-helpers/TransientWidget.h
@@ -73,7 +73,7 @@ inline void TransientWidget<T>::setInDom(bool inDom)
 {
     if (inDom && uniquePtr)
     {
-        ptr = parent->addWidget(uniquePtr);
+        ptr = parent->addWidget(std::move(uniquePtr));
     }
     else if (ptr)
     {

--- a/src/wt-helpers/TransientWidget.h
+++ b/src/wt-helpers/TransientWidget.h
@@ -77,7 +77,7 @@ inline void TransientWidget<T>::setInDom(bool inDom)
     }
     else if (ptr)
     {
-        uniquePtr.set(parent->removeChild(ptr));
+        uniquePtr = parent->removeChild(ptr);
         ptr = nullptr;
     }
 

--- a/src/wt-helpers/TransientWidget.h
+++ b/src/wt-helpers/TransientWidget.h
@@ -1,7 +1,7 @@
 #ifndef TRANSIENTWIDGET_H
 #define TRANSIENTWIDGET_H
 
-#include <Wt/WContainerWidget.h>
+#include <Wt/WContainerWidget.h>    // IWYU pragma: keep
 
 #include <memory>
 #include <type_traits>

--- a/src/wt-helpers/TranslatableMessage.cpp
+++ b/src/wt-helpers/TranslatableMessage.cpp
@@ -3,8 +3,8 @@
 #include <Wt/Json/Value.h>
 #include <Wt/WString.h>
 
-#include <string>
 #include <string_view>
+#include <vector>
 
 #include "TranslatableMessage.h"
 


### PR DESCRIPTION
This fixes solvernia's build against this library.
- Updated `static_assert`
- Use `std::move` on uniquePtr
- `InputGroup::getMainInput` can't return a const since we might want to do stuff with it